### PR TITLE
fix: handle escaped quotes inside Flex quoted string patterns (#30)

### DIFF
--- a/server/src/providers/diagnostics.ts
+++ b/server/src/providers/diagnostics.ts
@@ -844,7 +844,7 @@ function validateFlexRegex(pat: string): string | null {
   // Convert Flex-specific syntax → approximate JS regex
   let p = pat
     .replace(/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g, 'x')           // {abbr} → placeholder
-    .replace(/"([^"]*)"/g, (_, s) =>                          // "str" → escaped literal
+    .replace(/"((?:[^"\\]|\\.)*)"/g, (_, s) =>                 // "str" → escaped literal (handles \" inside)
       s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
     .replace(/\[:(alpha|upper|lower):\]/g, 'a-zA-Z')         // POSIX classes (inside [...])
     .replace(/\[:digit:\]/g, '0-9')

--- a/tests/test-diagnostic-codes.ts
+++ b/tests/test-diagnostic-codes.ts
@@ -377,6 +377,25 @@ console.log('\n=== TEST: Bug regressions ===');
   assert(unreachable.length === 0, '#23 no false flex/unreachable-rule for exclusive SC block');
 }
 
+// Issue #30 — quoted strings containing escaped quotes: "\'" and "\"" must NOT
+// produce flex/invalid-pattern. The "([^"]*)" replacement was stopping at the
+// first " inside the escaped sequence, corrupting the character class that follows.
+{
+  // Pattern: X"\'"[^'\n]*"\'"  (quoted single-quote literal on both sides)
+  const src1 = '%option noyywrap\n%%\nX"\\\'"\t[^\'\\n]*"\\\'"\t{}\n%%\n';
+  const doc1 = require('../server/src/parser/flexParser').parseFlexDocument(src1);
+  const diags1 = computeFlexDiagnostics(doc1, src1);
+  const inv1 = diags1.filter(d => d.code === 'flex/invalid-pattern');
+  assert(inv1.length === 0, '#30 pattern with escaped single-quote in quoted string must not produce flex/invalid-pattern');
+
+  // Pattern: X"\""[^"\n]*"\""  (quoted double-quote literal on both sides)
+  const src2 = '%option noyywrap\n%%\nX"\\""\t[^"\\n]*"\\""\t{}\n%%\n';
+  const doc2 = require('../server/src/parser/flexParser').parseFlexDocument(src2);
+  const diags2 = computeFlexDiagnostics(doc2, src2);
+  const inv2 = diags2.filter(d => d.code === 'flex/invalid-pattern');
+  assert(inv2.length === 0, '#30 pattern with escaped double-quote in quoted string must not produce flex/invalid-pattern');
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Results
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Type of change
- [x] Bug fix

## What does this PR do?

Fixes a false positive `flex/invalid-pattern` diagnostic triggered by Flex patterns containing escaped quotes inside quoted strings (e.g. `"\""`, `"\'"` followed by a character class).

Root cause: `validateFlexRegex()` used `"([^"]*)"` to strip Flex quoted strings, which stopped at the first `"` encountered — even when that `"` was escaped (`\"`). This left a dangling `"` that corrupted the rest of the pattern (e.g., absorbing the `[` of a following character class), causing a spurious invalid-pattern error.

Fix: changed the replacement regex to `"((?:[^"\\]|\\.)*)"` so escaped characters (including `\"`) inside quoted strings are handled correctly.

## Related issue
Closes #30

## How to test manually

Open a `.l` file containing:
```flex
%%
X"\""   [^"\n]*"\""   {}
X"\'"   [^'\n]*"\'"   {}
%%
```
No `flex/invalid-pattern` diagnostic should appear.

## Checklist
- [x] `npm run compile` passes with no new errors
- [x] Tests added or updated — 2 new assertions in `tests/test-diagnostic-codes.ts` (182 total)
- [x] Manual test done in VS Code
- [ ] CHANGELOG.md updated
- [x] No unintended files staged (node_modules, .env, dist...)