### PR TITLE
chore: release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the **Bison/Flex Language Support** extension will be documented in this file.
 
+## [1.5.2] - 2026-04-03
+
+### Fixed
+
+- **Flex — SC refs in multi-line block headers** (#38): in `<SC_A,\nSC_B,\nSC_C>{` multi-line syntax, only the SC on the closing line was recorded as a start-condition reference; all preceding SCs had 0 refs, causing false `flex/unused-sc` diagnostics and incorrect Code Lens counts.
+- **Flex — abbreviation refs on indented rule lines** (#38): `{ABBR}` on a rule line indented inside a `<SC>{ }` block was not recorded as an abbreviation reference. The `actionStart` heuristic mistook the leading whitespace before `{ABBR}` itself as the action opener, making `m.index < actionStart` false for all such lines.
+- **Flex — transitive abbreviation references** (#38): abbreviations used only inside another abbreviation's definition (e.g. `ALNUM_LITERAL {ALNUM_LITERAL_Q}|{ALNUM_LITERAL_A}`) were never recorded as referenced, producing false `flex/unused-abbrev` for the inner abbreviations. The parser now scans each definition body for `{name}` references.
+- **Flex — `flex/unreachable-rule` false positive for patterns with mandatory non-class groups** (#38): `isWordPattern` returned `true` for any pattern starting with `[a-zA-Z_` regardless of what followed, so `[_0-9A-Z]+(\.[_0-9A-Z]+)+` (which requires a literal dot and cannot match a plain keyword) was treated as a general identifier pattern, producing false `flex/unreachable-rule` warnings for keyword rules that followed it. `isWordPattern` now requires the entire pattern to consist solely of character-class groups.
+
+---
+
 ## [1.5.1] - 2026-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to the **Bison/Flex Language Support** extension will be documented in this file.
 
-## [1.5.2] - 2026-04-03
+## [1.5.2] - 2026-04-05
+
+### Added
+
+- **Flex — Code Lens for abbreviations** (#39): abbreviation definitions in the definitions section now show a clickable "N references" Code Lens, consistent with start conditions and Bison rules. Clicking opens the References panel with all `{ABBR}` usages in the rules section.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bison-flex-lang",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bison-flex-lang",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bison-flex-lang",
   "displayName": "Bison/Flex Language Support",
   "description": "Full-featured language support for GNU Bison (.y, .yy) and Flex/RE-flex (.l, .ll) — syntax highlighting with embedded C/C++, real-time diagnostics, intelligent autocompletion, and hover documentation for all directives.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "publisher": "theodevelop",
   "license": "MIT",
   "repository": {

--- a/server/src/parser/flexParser.ts
+++ b/server/src/parser/flexParser.ts
@@ -232,10 +232,17 @@ export function parseFlexDocument(text: string): FlexDocument {
     if (pendingScHeader !== null) {
       const closeIdx = trimmed.indexOf('>');
       if (closeIdx >= 0) {
-        // Collect any additional SC names before the >
+        // Collect any additional SC names before the > and record their refs on this line
         const before = trimmed.substring(0, closeIdx);
         const moreConds = before.match(/[A-Za-z_][A-Za-z0-9_]*/g);
-        if (moreConds) pendingScHeader += ',' + moreConds.join(',');
+        if (moreConds) {
+          for (const cond of moreConds) {
+            const col = line.indexOf(cond);
+            if (!doc.startConditionRefs.has(cond)) doc.startConditionRefs.set(cond, []);
+            doc.startConditionRefs.get(cond)!.push(Range.create(i, col >= 0 ? col : 0, i, (col >= 0 ? col : 0) + cond.length));
+          }
+          pendingScHeader += ',' + moreConds.join(',');
+        }
         const conds = pendingScHeader.replace(/^,+/, '').split(',').filter(s => s.length > 0);
         pendingScHeader = null;
         // Expect '{' right after '>' to open the SC block
@@ -245,9 +252,16 @@ export function parseFlexDocument(text: string): FlexDocument {
           // actionDepth stays 0; the { is the SC block opening, not an action block
         }
       } else {
-        // Still accumulating conditions from this line
+        // Still accumulating conditions from this line — record their refs
         const moreConds = trimmed.match(/[A-Za-z_][A-Za-z0-9_]*/g);
-        if (moreConds) pendingScHeader += ',' + moreConds.join(',');
+        if (moreConds) {
+          for (const cond of moreConds) {
+            const col = line.indexOf(cond);
+            if (!doc.startConditionRefs.has(cond)) doc.startConditionRefs.set(cond, []);
+            doc.startConditionRefs.get(cond)!.push(Range.create(i, col >= 0 ? col : 0, i, (col >= 0 ? col : 0) + cond.length));
+          }
+          pendingScHeader += ',' + moreConds.join(',');
+        }
       }
       continue;
     }
@@ -295,7 +309,13 @@ export function parseFlexDocument(text: string): FlexDocument {
       // Multi-line header start: <SC1,   (no closing > on this line)
       const scMultiStart = trimmed.match(/^<([A-Za-z_][A-Za-z0-9_]*(?:,[A-Za-z_][A-Za-z0-9_]*)*,\s*)$/);
       if (scMultiStart) {
-        pendingScHeader = scMultiStart[1].replace(/,\s*$/, '');
+        const firstConds = scMultiStart[1].replace(/,\s*$/, '').split(',').filter(s => s.length > 0);
+        for (const cond of firstConds) {
+          const col = line.indexOf(cond, line.indexOf('<'));
+          if (!doc.startConditionRefs.has(cond)) doc.startConditionRefs.set(cond, []);
+          doc.startConditionRefs.get(cond)!.push(Range.create(i, col >= 0 ? col : 0, i, (col >= 0 ? col : 0) + cond.length));
+        }
+        pendingScHeader = firstConds.join(',');
         continue;
       }
     }
@@ -319,13 +339,15 @@ export function parseFlexDocument(text: string): FlexDocument {
     // ── Extract abbreviation references: {name} (but not C code {}) ───────────
     // Only match {name} where name is a valid identifier
     const abbrRefs = line.matchAll(/\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g);
+    // To find the action opener '{', first strip all {name} abbreviation refs so that
+    // the leading whitespace before {name} on an indented rule line does not confuse
+    // the \s+{ search into matching the abbreviation's own '{' instead of the action '{'.
+    const strippedForAction = line.replace(/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g, m => ' '.repeat(m.length));
+    const actionMatch = strippedForAction.match(/\s+\{/);
+    const actionStart = actionMatch !== null ? (actionMatch.index! + actionMatch[0].length - 1) : line.length;
     for (const m of abbrRefs) {
       const name = m[1];
-      // Only count as abbreviation ref if it appears before any action block on this line.
-      // If there is no action { on this line (multi-line action), treat actionStart as line.length
-      // so all {name} refs on this line are counted.
-      const actionMatch = line.match(/\s+\{/);
-      const actionStart = actionMatch !== null ? line.indexOf('{', actionMatch.index!) : line.length;
+      // Only count as abbreviation ref if it appears before the action block on this line.
       if (m.index !== undefined && m.index < actionStart) {
         const col = m.index;
         const range = Range.create(i, col, i, col + m[0].length);

--- a/server/src/parser/flexParser.ts
+++ b/server/src/parser/flexParser.ts
@@ -182,6 +182,17 @@ export function parseFlexDocument(text: string): FlexDocument {
         pattern,
         location: Range.create(i, 0, i, name.length),
       });
+      // Record inter-abbreviation references: if this definition body
+      // contains {OTHER}, mark OTHER as referenced so it is not flagged
+      // as unused just because it only appears inside another abbreviation.
+      const patStart = line.indexOf(abbrMatch[2]);
+      for (const ref of pattern.matchAll(/\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g)) {
+        const refName = ref[1];
+        const refCol = patStart >= 0 ? patStart + ref.index! : ref.index!;
+        const range = Range.create(i, refCol, i, refCol + ref[0].length);
+        if (!doc.abbreviationRefs.has(refName)) doc.abbreviationRefs.set(refName, []);
+        doc.abbreviationRefs.get(refName)!.push(range);
+      }
       continue;
     }
 

--- a/server/src/providers/codeLens.ts
+++ b/server/src/providers/codeLens.ts
@@ -3,8 +3,9 @@ import { DocumentModel, BisonDocument, FlexDocument, isBisonDocument } from '../
 
 /**
  * Code Lenses:
- *   Bison rules   → "N references"  +  "⬤ entry point" (start symbol only)
- *   Flex SC decls → "N references"
+ *   Bison rules        → "N references"  +  "⬤ entry point" (start symbol only)
+ *   Flex SC decls      → "N references"
+ *   Flex abbreviations → "N references"
  *
  * The "N references" lens triggers `bisonFlex.showReferences` (registered
  * client-side) which calls `editor.action.showReferences` with pre-built args.
@@ -67,6 +68,22 @@ function getFlexCodeLenses(doc: FlexDocument, uri: string): CodeLens[] {
         'bisonFlex.showReferences',
         uri,
         { line, character: sc.location.start.character },
+      ),
+    });
+  }
+
+  for (const [name, abbr] of doc.abbreviations) {
+    const line = abbr.location.start.line;
+    const lensRange = Range.create(line, 0, line, 0);
+    const refCount = doc.abbreviationRefs.get(name)?.length ?? 0;
+
+    lenses.push({
+      range: lensRange,
+      command: Command.create(
+        `$(references) ${refCount} reference${refCount !== 1 ? 's' : ''}`,
+        'bisonFlex.showReferences',
+        uri,
+        { line, character: abbr.location.start.character },
       ),
     });
   }

--- a/server/src/providers/diagnostics.ts
+++ b/server/src/providers/diagnostics.ts
@@ -879,11 +879,14 @@ function getLiteralKeyword(pat: string): string | null {
  * i.e., could match arbitrary letter sequences including keywords.
  */
 function isWordPattern(pat: string): boolean {
-  // Character class starting with a letter or underscore range: [a-z...], [A-Z...], [_...]
-  if (/^\[[a-zA-Z_]/.test(pat)) return true;
+  // Only patterns that are purely sequences of character-class groups (e.g., [A-Z_]+ or
+  // [a-z][a-z0-9]*) count as "word patterns" that can shadow keyword literals.
+  // Patterns with mandatory non-class components — such as [A-Z]+(\.[A-Z]+)+ which
+  // requires a literal dot — cannot match simple keyword strings and must be excluded.
+  if (/^\[[a-zA-Z_]/.test(pat) && /^(\[(?:[^\]\\]|\\.)*\][+*?]?)+$/.test(pat)) return true;
   // POSIX character-class expressions that match letter sequences: [[:alpha:]], [[:alnum:]], etc.
-  if (/^\[\[:(alpha|upper|lower|alnum|word):\]/.test(pat)) return true;
+  if (/^\[\[:(alpha|upper|lower|alnum|word):\]\][+*?]*$/.test(pat)) return true;
   // Common abbreviation references for identifiers
-  if (/^\{(id|identifier|ident|IDENT|word|alpha)\}/.test(pat)) return true;
+  if (/^\{(id|identifier|ident|IDENT|word|alpha)\}$/.test(pat)) return true;
   return false;
 }

--- a/server/src/providers/diagnostics.ts
+++ b/server/src/providers/diagnostics.ts
@@ -879,13 +879,15 @@ function getLiteralKeyword(pat: string): string | null {
  * i.e., could match arbitrary letter sequences including keywords.
  */
 function isWordPattern(pat: string): boolean {
-  // Only patterns that are purely sequences of character-class groups (e.g., [A-Z_]+ or
-  // [a-z][a-z0-9]*) count as "word patterns" that can shadow keyword literals.
-  // Patterns with mandatory non-class components — such as [A-Z]+(\.[A-Z]+)+ which
-  // requires a literal dot — cannot match simple keyword strings and must be excluded.
+  // POSIX character-class expressions that match letter sequences (e.g., [[:alpha:]],
+  // [[:alnum:]], or chains like [[:alpha:]][[:alnum:]_]*). A prefix check is sufficient
+  // because these patterns cannot embed mandatory non-letter components.
+  if (/^\[\[:(alpha|upper|lower|alnum|word):\]/.test(pat)) return true;
+  // Simple character-class patterns (e.g., [A-Z_]+ or [a-z][a-z0-9]*): only match when
+  // the ENTIRE pattern consists of character-class groups. Patterns with mandatory
+  // non-class suffixes — e.g., [A-Z]+(\.[A-Z]+)+ which requires a literal dot —
+  // cannot match plain keyword strings and must not trigger the shadowing warning.
   if (/^\[[a-zA-Z_]/.test(pat) && /^(\[(?:[^\]\\]|\\.)*\][+*?]?)+$/.test(pat)) return true;
-  // POSIX character-class expressions that match letter sequences: [[:alpha:]], [[:alnum:]], etc.
-  if (/^\[\[:(alpha|upper|lower|alnum|word):\]\][+*?]*$/.test(pat)) return true;
   // Common abbreviation references for identifiers
   if (/^\{(id|identifier|ident|IDENT|word|alpha)\}$/.test(pat)) return true;
   return false;

--- a/tests/test-diagnostic-codes.ts
+++ b/tests/test-diagnostic-codes.ts
@@ -556,6 +556,73 @@ console.log('\n=== TEST: Issue #38 — SC refs and abbrev refs ===');
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Transitive abbreviation references (pplex.l scenario)
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n=== TEST: Transitive abbreviation references ===');
+
+{
+  // ALNUM_Q and ALNUM_A are used inside ALNUM's definition, not directly in rules.
+  // They must be counted as referenced so no flex/unused-abbrev is produced.
+  const src = [
+    '%option noyywrap',
+    'ALNUM_Q\t"(\\"[^\\n])*\\""',
+    'ALNUM_A\t"(\\\'[^\\n])*\\\'"',
+    'ALNUM\t{ALNUM_Q}|{ALNUM_A}',
+    '%%',
+    '{ALNUM}\t{ return 1; }',
+    '%%',
+  ].join('\n');
+  const doc = require('../server/src/parser/flexParser').parseFlexDocument(src);
+  assert(doc.abbreviationRefs.has('ALNUM_Q') && doc.abbreviationRefs.get('ALNUM_Q').length >= 1,
+    'transitive-abbrev: ALNUM_Q used in ALNUM definition recorded in abbreviationRefs');
+  assert(doc.abbreviationRefs.has('ALNUM_A') && doc.abbreviationRefs.get('ALNUM_A').length >= 1,
+    'transitive-abbrev: ALNUM_A used in ALNUM definition recorded in abbreviationRefs');
+  const diags = computeFlexDiagnostics(doc, src);
+  const unusedAbbr = diags.filter(d => d.code === 'flex/unused-abbrev');
+  assert(unusedAbbr.length === 0, 'transitive-abbrev: no flex/unused-abbrev for abbreviations used only inside another abbreviation');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isWordPattern: complex patterns with mandatory groups must not shadow keywords
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n=== TEST: isWordPattern — complex patterns do not shadow keywords ===');
+
+{
+  // [A-Z]+(\.[A-Z]+)+ requires a dot → cannot match "IN" or "OF"
+  // No flex/unreachable-rule should be produced for those keyword rules.
+  const src = [
+    '%option noyywrap',
+    '%x COPY_STATE',
+    '%%',
+    '<COPY_STATE>{',
+    '  [_0-9A-Z]+(\\.[_0-9A-Z]+)+\t{ return TEXT; }',
+    '  "IN"\t{ return 1; }',
+    '  "OF"\t{ return 2; }',
+    '}',
+    '%%',
+  ].join('\n');
+  const doc = require('../server/src/parser/flexParser').parseFlexDocument(src);
+  const diags = computeFlexDiagnostics(doc, src);
+  const unreachable = diags.filter(d => d.code === 'flex/unreachable-rule');
+  assert(unreachable.length === 0, 'isWordPattern: keyword rules after [A-Z]+(\\.[A-Z]+)+ must not produce flex/unreachable-rule');
+}
+
+{
+  // [A-Z_]+ IS a simple word pattern → "IF" after it should produce flex/unreachable-rule
+  const src = [
+    '%option noyywrap',
+    '%%',
+    '[A-Z_]+\t{ return WORD; }',
+    '"IF"\t{ return IF_KW; }',
+    '%%',
+  ].join('\n');
+  const doc = require('../server/src/parser/flexParser').parseFlexDocument(src);
+  const diags = computeFlexDiagnostics(doc, src);
+  const unreachable = diags.filter(d => d.code === 'flex/unreachable-rule');
+  assert(unreachable.length >= 1, 'isWordPattern: simple [A-Z_]+ still shadows keyword "IF" → flex/unreachable-rule expected');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Bison audit checks
 // ─────────────────────────────────────────────────────────────────────────────
 console.log('\n=== TEST: Bison audit checks ===');

--- a/tests/test-diagnostic-codes.ts
+++ b/tests/test-diagnostic-codes.ts
@@ -506,6 +506,56 @@ console.log('\n=== TEST: Flex audit checks ===');
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Issue #38 — SC refs in multi-line lists / abbrev refs on indented rule lines
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n=== TEST: Issue #38 — SC refs and abbrev refs ===');
+
+{
+  // Multi-line SC block header: all SCs must be recorded in startConditionRefs
+  const src = [
+    '%option noyywrap',
+    '%x SC_A SC_B SC_C',
+    '%%',
+    '<SC_A,',
+    'SC_B,',
+    'SC_C>{',
+    '  [a-z]+ { return 1; }',
+    '}',
+    '%%',
+  ].join('\n');
+  const doc = require('../server/src/parser/flexParser').parseFlexDocument(src);
+  assert(doc.startConditionRefs.has('SC_A') && doc.startConditionRefs.get('SC_A').length >= 1,
+    '#38: SC_A in multi-line block header recorded in startConditionRefs');
+  assert(doc.startConditionRefs.has('SC_B') && doc.startConditionRefs.get('SC_B').length >= 1,
+    '#38: SC_B in multi-line block header recorded in startConditionRefs');
+  assert(doc.startConditionRefs.has('SC_C') && doc.startConditionRefs.get('SC_C').length >= 1,
+    '#38: SC_C (on resolution line) in multi-line block header recorded in startConditionRefs');
+  const diags = computeFlexDiagnostics(doc, src);
+  const unusedSC = diags.filter(d => d.code === 'flex/unused-sc');
+  assert(unusedSC.length === 0, '#38: no false flex/unused-sc for SCs in multi-line block header');
+}
+
+{
+  // Abbrev ref on indented rule line must be counted even with leading whitespace
+  const src = [
+    '%option noyywrap',
+    'DIGIT [0-9]+',
+    '%x ST',
+    '%%',
+    '<ST>{',
+    '  {DIGIT} { return 1; }',
+    '}',
+    '%%',
+  ].join('\n');
+  const doc = require('../server/src/parser/flexParser').parseFlexDocument(src);
+  assert(doc.abbreviationRefs.has('DIGIT') && doc.abbreviationRefs.get('DIGIT').length >= 1,
+    '#38: {DIGIT} on indented rule line inside SC block recorded in abbreviationRefs');
+  const diags = computeFlexDiagnostics(doc, src);
+  const unusedAbbr = diags.filter(d => d.code === 'flex/unused-abbrev');
+  assert(unusedAbbr.length === 0, '#38: no false flex/unused-abbrev for abbrev used on indented rule line');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Bison audit checks
 // ─────────────────────────────────────────────────────────────────────────────
 console.log('\n=== TEST: Bison audit checks ===');

--- a/tests/test-diagnostic-codes.ts
+++ b/tests/test-diagnostic-codes.ts
@@ -623,6 +623,35 @@ console.log('\n=== TEST: isWordPattern — complex patterns do not shadow keywor
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Issue #39 — Code Lens for abbreviations
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\n=== TEST: Issue #39 — Code Lens for abbreviations ===');
+
+{
+  const { getCodeLenses } = require('../server/src/providers/codeLens');
+  const src = [
+    '%option noyywrap',
+    'DIGIT  [0-9]+',
+    'WORD   [a-z]+',
+    '%%',
+    '{DIGIT}  { return 1; }',
+    '{DIGIT}  { return 2; }',
+    '%%',
+  ].join('\n');
+  const doc = require('../server/src/parser/flexParser').parseFlexDocument(src);
+  const lenses = getCodeLenses(doc, 'file:///test.l');
+
+  // DIGIT is on line 1, WORD on line 2
+  const digitLens = lenses.find((l: any) => l.range.start.line === 1);
+  const wordLens  = lenses.find((l: any) => l.range.start.line === 2);
+
+  assert(!!digitLens, '#39: Code Lens produced for DIGIT abbreviation');
+  assert(digitLens?.command?.title?.includes('2'), '#39: DIGIT lens shows 2 references (used twice in rules)');
+  assert(!!wordLens,  '#39: Code Lens produced for WORD abbreviation');
+  assert(wordLens?.command?.title?.includes('0'), '#39: WORD lens shows 0 references (unused)');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Bison audit checks
 // ─────────────────────────────────────────────────────────────────────────────
 console.log('\n=== TEST: Bison audit checks ===');


### PR DESCRIPTION
## Summary

Aggregated PR for v1.5.2 — four false-positive fixes from issue #38 (discovered
while testing against a real-world Flex file) and one new feature (#39).

## Changes

### Fixed (#38)
- **SC refs in multi-line block headers**: `<SC_A,\nSC_B,\nSC_C>{` only recorded
  the closing SC; all others had 0 refs → false `flex/unused-sc` and wrong Code Lens counts.
- **Abbrev refs on indented rule lines**: `{ABBR}` inside an indented `<SC>{ }` block
  was not counted as an abbreviation reference → false `flex/unused-abbrev`.
- **Transitive abbreviation references**: abbreviations used only inside another
  abbreviation's definition (e.g. `ALNUM {ALNUM_Q}|{ALNUM_A}`) were never recorded
  as referenced → false `flex/unused-abbrev` for the inner abbreviations.
- **`flex/unreachable-rule` false positive for complex patterns**: `isWordPattern`
  classified `[A-Z]+(\.[A-Z]+)+` (requires a literal dot) as a general identifier
  pattern, producing false shadowing warnings for keyword rules that followed it.

### Added (#39)
- **Code Lens for Flex abbreviations**: abbreviation definitions now show a clickable
  "N references" lens, consistent with start conditions and Bison rules.

## Tests
- 356 parser tests, 211 diagnostic-code tests — 0 failed.

## Checklist
- [x] `npm run compile` clean
- [x] All test suites pass
- [x] CHANGELOG.md updated
- [x] `package.json` version bumped to 1.5.2