### PR TITLE
feat: add Bison/Flex Navigation output channel for Show in Generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Jump between Bison/Flex grammar sources and their generated C files using `#line
 - **Bison/Flex: Show in Source** — from a generated `.tab.c` / `lex.yy.c` file, reads the nearest `#line N "file.y"` directive above the cursor and opens the grammar source at the correct line. Appears in the context menu only when a generated file is detected.
 - **Bison/Flex: Show in Generated File** — from a `.y` / `.l` source, locates the generated file and navigates to the matching line. Searches `bisonFlex.buildDirectory`, then CMake/Makefile detection, then the same directory, then a workspace-wide scan. A QuickPick is shown when multiple candidates are found.
 
+#### Configuring `bisonFlex.buildDirectory`
+
+Set this to the directory where Bison/Flex writes its generated files when they are not placed next to the source:
+
+- **`${workspaceFolder}`** — resolved to the workspace folder that contains the source file. In multi-root workspaces each folder resolves independently, so a single setting works across all roots.
+- **Relative path** — resolved relative to that same workspace folder (e.g. `build` or `cmake-build-debug/parser`).
+- **Absolute path** — used as-is.
+
+If the setting is empty or the generated file is not found there, the extension falls back to CMake/Makefile-detected paths, then the source file's own directory, then a workspace-wide scan.
+
 ### Autocompletion
 
 Context-aware suggestions triggered as you type:
@@ -226,7 +236,7 @@ Then press `F5` in VS Code to launch the Extension Development Host.
 | `bisonFlex.minVersionBison` | `string` | `""` | Suppress checks that require a newer Bison version (e.g. `"3.0"`). Fires `bison/feature-requires-version` when a `%define` feature exceeds this version. |
 | `bisonFlex.minVersionFlex` | `string` | `""` | Same as above for Flex. |
 | `bisonFlex.disabledChecks` | `array` | `[]` | Diagnostic code slugs to suppress entirely (e.g. `["bison/shift-reduce", "flex/missing-yywrap"]`). |
-| `bisonFlex.buildDirectory` | `string` | `""` | Path to the build output directory. Used by **Show in Generated File** to locate `.tab.c` / `lex.yy.c` when they are not next to the source. |
+| `bisonFlex.buildDirectory` | `string` | `""` | Directory where Bison/Flex writes its generated files (`.tab.c`, `lex.yy.c`). Supports `${workspaceFolder}` (resolved per workspace root in multi-root setups), paths relative to that root, and absolute paths. See [Configuring `bisonFlex.buildDirectory`](#configuring-bisonflexbuilddirectory) for details. |
 
 ---
 

--- a/client/src/lineDirectiveNavigation.ts
+++ b/client/src/lineDirectiveNavigation.ts
@@ -59,7 +59,10 @@ function getNavChannel(): OutputChannel {
   return navChannel;
 }
 
-/** Resolve `bisonFlex.buildDirectory`: substitutes ${workspaceFolder} and resolves relative paths. */
+/** Resolve `bisonFlex.buildDirectory`: substitutes ${workspaceFolder} and resolves relative paths.
+ *  In multi-root workspaces, folders[0] is used as the root for relative paths.
+ *  workspaceFile is intentionally not used: a .code-workspace file can be stored anywhere
+ *  outside the workspace, making it unsuitable as a base for resolving grammar paths. */
 function resolveSettingBuildDir(rawDir: string, sourceFilePath: string): string {
   const wsFolder = workspace.workspaceFolders?.[0]?.uri.fsPath ?? path.dirname(sourceFilePath);
   let resolved = rawDir.replace(/\$\{workspaceFolder\}/g, wsFolder);
@@ -153,11 +156,18 @@ function findMakefileBuildDir(sourceFilePath: string): string | undefined {
   return undefined;
 }
 
+let lastFoundCache: { sourceFilePath: string; buildDir: string; generatedPath: string } | undefined;
+
 /** Locate the generated file corresponding to a grammar source file. */
 async function findGeneratedFile(sourceFilePath: string): Promise<string | null> {
   const ch = getNavChannel();
   const config = workspace.getConfiguration('bisonFlex');
   const rawBuildDir = config.get<string>('buildDirectory', '').trim();
+
+  if (lastFoundCache?.sourceFilePath === sourceFilePath && lastFoundCache.buildDir === rawBuildDir) {
+    return lastFoundCache.generatedPath;
+  }
+
   const settingBuildDir = rawBuildDir ? resolveSettingBuildDir(rawBuildDir, sourceFilePath) : undefined;
   const sourceDir = path.dirname(sourceFilePath);
   const base = path.basename(sourceFilePath, path.extname(sourceFilePath));
@@ -187,6 +197,7 @@ async function findGeneratedFile(sourceFilePath: string): Promise<string | null>
       ch.appendLine(`    ${c}`);
       if (fs.existsSync(c)) {
         ch.appendLine(`  ✓ found: ${c}`);
+        lastFoundCache = { sourceFilePath, buildDir: rawBuildDir, generatedPath: c };
         return c;
       }
     }
@@ -212,6 +223,7 @@ async function findGeneratedFile(sourceFilePath: string): Promise<string | null>
   }
   if (found.length === 1) {
     ch.appendLine(`  ✓ found (workspace): ${found[0].fsPath}`);
+    lastFoundCache = { sourceFilePath, buildDir: rawBuildDir, generatedPath: found[0].fsPath };
     return found[0].fsPath;
   }
 
@@ -220,7 +232,11 @@ async function findGeneratedFile(sourceFilePath: string): Promise<string | null>
     { placeHolder: 'Multiple generated files found — select one' }
   );
   ch.appendLine(`  ✓ user selected: ${pick?.fsPath ?? '(cancelled)'}`);
-  return pick ? pick.fsPath : null;
+  if (pick) {
+    lastFoundCache = { sourceFilePath, buildDir: rawBuildDir, generatedPath: pick.fsPath };
+    return pick.fsPath;
+  }
+  return null;
 }
 
 /**

--- a/client/src/lineDirectiveNavigation.ts
+++ b/client/src/lineDirectiveNavigation.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { window, workspace, Uri, Position, Range, ViewColumn } from 'vscode';
+import { window, workspace, Uri, Position, Range, ViewColumn, OutputChannel } from 'vscode';
 
 export { isGeneratedFile } from './lineDirectiveUtils';
 import { isGeneratedFile, findNearestLineDirective } from './lineDirectiveUtils';
@@ -49,6 +49,24 @@ export async function showInSource(): Promise<void> {
   const doc = await workspace.openTextDocument(Uri.file(sourcePath));
   const pos = new Position(targetLine, 0);
   await window.showTextDocument(doc, { selection: new Range(pos, pos), viewColumn: ViewColumn.Active });
+}
+
+// ── Navigation output channel ────────────────────────────────────────────────
+
+let navChannel: OutputChannel | undefined;
+function getNavChannel(): OutputChannel {
+  if (!navChannel) navChannel = window.createOutputChannel('Bison/Flex Navigation');
+  return navChannel;
+}
+
+/** Resolve `bisonFlex.buildDirectory`: substitutes ${workspaceFolder} and resolves relative paths. */
+function resolveSettingBuildDir(rawDir: string, sourceFilePath: string): string {
+  const wsFolder = workspace.workspaceFolders?.[0]?.uri.fsPath ?? path.dirname(sourceFilePath);
+  let resolved = rawDir.replace(/\$\{workspaceFolder\}/g, wsFolder);
+  if (!path.isAbsolute(resolved)) {
+    resolved = path.resolve(wsFolder, resolved);
+  }
+  return resolved;
 }
 
 // ── Direction 2: source → generated ──────────────────────────────────────────
@@ -137,13 +155,23 @@ function findMakefileBuildDir(sourceFilePath: string): string | undefined {
 
 /** Locate the generated file corresponding to a grammar source file. */
 async function findGeneratedFile(sourceFilePath: string): Promise<string | null> {
+  const ch = getNavChannel();
   const config = workspace.getConfiguration('bisonFlex');
-  const settingBuildDir = config.get<string>('buildDirectory', '').trim() || undefined;
+  const rawBuildDir = config.get<string>('buildDirectory', '').trim();
+  const settingBuildDir = rawBuildDir ? resolveSettingBuildDir(rawBuildDir, sourceFilePath) : undefined;
   const sourceDir = path.dirname(sourceFilePath);
   const base = path.basename(sourceFilePath, path.extname(sourceFilePath));
   const ext = path.extname(sourceFilePath).toLowerCase();
   const isBison = ['.y', '.yy', '.y++', '.ypp', '.yxx', '.bison'].includes(ext);
   const candidates = isBison ? BISON_CANDIDATES : FLEX_CANDIDATES;
+
+  ch.show(true);
+  ch.appendLine(`\n─── Show in Generated: ${path.basename(sourceFilePath)} ───`);
+  if (rawBuildDir) {
+    ch.appendLine(`  buildDirectory: "${rawBuildDir}" → ${settingBuildDir}`);
+  } else {
+    ch.appendLine(`  buildDirectory: (not set)`);
+  }
 
   const dirsToTry: string[] = [];
   if (settingBuildDir) dirsToTry.push(settingBuildDir);
@@ -154,12 +182,18 @@ async function findGeneratedFile(sourceFilePath: string): Promise<string | null>
   dirsToTry.push(sourceDir);
 
   for (const dir of dirsToTry) {
+    ch.appendLine(`  dir: ${dir}`);
     for (const c of candidates(base, dir)) {
-      if (fs.existsSync(c)) return c;
+      ch.appendLine(`    ${c}`);
+      if (fs.existsSync(c)) {
+        ch.appendLine(`  ✓ found: ${c}`);
+        return c;
+      }
     }
   }
 
   // Workspace-wide search as last resort — let user pick if ambiguous
+  ch.appendLine(`  → no local match, trying workspace search`);
   let pattern = isBison ? `**/${base}.tab.{c,cpp,cc}` : `**/lex.yy.{c,cc}`;
   let found = await workspace.findFiles(pattern, '**/node_modules/**', 10);
 
@@ -168,16 +202,24 @@ async function findGeneratedFile(sourceFilePath: string): Promise<string | null>
   // the tool's default names are available somewhere in the workspace
   if (found.length === 0) {
     pattern = `**/${base}.{c,cc,c++,cxx,cpp}`;
+    ch.appendLine(`  → retrying with ylwrap pattern: ${pattern}`);
     found = await workspace.findFiles(pattern, '**/node_modules/**', 10);
   }
-  
-  if (found.length === 0) return null;
-  if (found.length === 1) return found[0].fsPath;
+
+  if (found.length === 0) {
+    ch.appendLine(`  ✗ not found`);
+    return null;
+  }
+  if (found.length === 1) {
+    ch.appendLine(`  ✓ found (workspace): ${found[0].fsPath}`);
+    return found[0].fsPath;
+  }
 
   const pick = await window.showQuickPick(
     found.map(u => ({ label: workspace.asRelativePath(u), fsPath: u.fsPath })),
     { placeHolder: 'Multiple generated files found — select one' }
   );
+  ch.appendLine(`  ✓ user selected: ${pick?.fsPath ?? '(cancelled)'}`);
   return pick ? pick.fsPath : null;
 }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor / internal improvement
- [ ] Docs / config only

## What does this PR do?
**Fix `bisonFlex.buildDirectory` not resolved (`client/src/lineDirectiveNavigation.ts`)**
The setting was used raw, causing `${workspaceFolder}/build, build/cobc` and `../build/cobc` to all fail silently. A new `resolveSettingBuildDir()` helper substitutes `${workspaceFolder}` and resolves relative paths against the workspace folder before searching.
**Add "Bison/Flex Navigation" output channel**
`Show in Generated File` now logs every directory and candidate file searched, plus the resolved `buildDirectory` value. The panel opens automatically (focus preserved) on each invocation to ease debugging.

## Related issue
Closes #27 

## How to test manually
1. Open a project with `cobc/parser.y` and a generated file in `build/cobc/parser.c`
2. Set `bisonFlex.buildDirectory` to `"build/cobc"`, `"${workspaceFolder}/build/cobc"` or a relative path
3. Right-click in `parser.y` → _Show in Generated File_
4. Check **Output → Bison/Flex Navigation** for the resolved path and files searched

## Checklist
- [x] `npm run compile` passes with no new errors
- [x] Tests added or updated (`npx ts-node ...`)
- [x] Manual test done in VS Code
- [ ] CHANGELOG.md updated
- [x] No unintended files staged (node_modules, .env, dist...)