### PR TITLE
feat: ProjectModel foundation — WorkspaceIndex and project scanner

### DIFF
--- a/server/src/project/projectModel.ts
+++ b/server/src/project/projectModel.ts
@@ -1,0 +1,96 @@
+import {
+  BisonFlexProjectModel,
+  BisonSourceFile,
+  FlexSourceFile,
+  ParserScannerPair,
+  GeneratedFile,
+  BuildSystemInfo,
+} from './projectTypes';
+import { scanWorkspace } from './projectScanner';
+
+export class WorkspaceIndex {
+  private model: BisonFlexProjectModel;
+
+  constructor(workspaceRoot: string) {
+    this.model = {
+      workspaceRoot,
+      parsers: [],
+      scanners: [],
+      pairs: [],
+      generatedFiles: [],
+      buildSystems: [],
+      lastScanned: 0,
+    };
+  }
+
+  async initialize(workspaceFolders: string[]): Promise<void> {
+    if (workspaceFolders.length === 0) return;
+
+    await new Promise<void>(resolve => {
+      setImmediate(async () => {
+        try {
+          this.model = await scanWorkspace(workspaceFolders);
+        } catch {
+          // degrade gracefully
+        }
+        resolve();
+      });
+    });
+  }
+
+  async onFileChange(uri: string, change: 'created' | 'deleted' | 'renamed'): Promise<void> {
+    if (change === 'deleted') {
+      this.model.parsers = this.model.parsers.filter(f => f.uri !== uri);
+      this.model.scanners = this.model.scanners.filter(f => f.uri !== uri);
+      this.model.pairs = this.model.pairs.filter(
+        p => p.parser.uri !== uri && p.scanner.uri !== uri,
+      );
+      this.model.generatedFiles = this.model.generatedFiles.filter(
+        f => f.uri !== uri && f.sourceUri !== uri,
+      );
+      this.model.lastScanned = Date.now();
+    } else {
+      // created or renamed — full re-scan (rare event)
+      const folders = this.model.workspaceRoot ? [this.model.workspaceRoot] : [];
+      if (folders.length > 0) {
+        try {
+          this.model = await scanWorkspace(folders);
+        } catch {
+          // degrade gracefully
+        }
+      }
+    }
+  }
+
+  getPairForBison(bisonUri: string): ParserScannerPair | undefined {
+    return this.model.pairs.find(p => p.parser.uri === bisonUri);
+  }
+
+  getPairForFlex(flexUri: string): ParserScannerPair | undefined {
+    return this.model.pairs.find(p => p.scanner.uri === flexUri);
+  }
+
+  getBisonFiles(): BisonSourceFile[] {
+    return this.model.parsers;
+  }
+
+  getFlexFiles(): FlexSourceFile[] {
+    return this.model.scanners;
+  }
+
+  getAllPairs(): ParserScannerPair[] {
+    return this.model.pairs;
+  }
+
+  getGeneratedFilesFor(sourceUri: string): GeneratedFile[] {
+    return this.model.generatedFiles.filter(f => f.sourceUri === sourceUri);
+  }
+
+  getBuildInfo(): BuildSystemInfo[] {
+    return this.model.buildSystems;
+  }
+
+  getModel(): BisonFlexProjectModel {
+    return this.model;
+  }
+}

--- a/server/src/project/projectModel.ts
+++ b/server/src/project/projectModel.ts
@@ -10,6 +10,7 @@ import { scanWorkspace } from './projectScanner';
 
 export class WorkspaceIndex {
   private model: BisonFlexProjectModel;
+  private workspaceFolders: string[] = [];
 
   constructor(workspaceRoot: string) {
     this.model = {
@@ -25,6 +26,7 @@ export class WorkspaceIndex {
 
   async initialize(workspaceFolders: string[]): Promise<void> {
     if (workspaceFolders.length === 0) return;
+    this.workspaceFolders = workspaceFolders;
 
     await new Promise<void>(resolve => {
       setImmediate(async () => {
@@ -51,10 +53,9 @@ export class WorkspaceIndex {
       this.model.lastScanned = Date.now();
     } else {
       // created or renamed — full re-scan (rare event)
-      const folders = this.model.workspaceRoot ? [this.model.workspaceRoot] : [];
-      if (folders.length > 0) {
+      if (this.workspaceFolders.length > 0) {
         try {
-          this.model = await scanWorkspace(folders);
+          this.model = await scanWorkspace(this.workspaceFolders);
         } catch {
           // degrade gracefully
         }

--- a/server/src/project/projectScanner.ts
+++ b/server/src/project/projectScanner.ts
@@ -1,0 +1,303 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+import {
+  BisonFlexProjectModel,
+  BisonSourceFile,
+  FlexSourceFile,
+  ParserScannerPair,
+  GeneratedFile,
+  BuildSystemInfo,
+} from './projectTypes';
+
+const EXCLUDE_DIRS = new Set(['node_modules', 'dist', '.git', 'vendor']);
+
+const BISON_EXTENSIONS = new Set(['.y', '.yy']);
+const FLEX_EXTENSIONS = new Set(['.l', '.ll']);
+
+const STEM_SUFFIXES = [
+  '_parser', '_scanner', '-parser', '-scanner',
+  'parser', 'scanner', '_lex', '_tab',
+];
+
+async function walkDir(
+  dir: string,
+  bisonFiles: BisonSourceFile[],
+  flexFiles: FlexSourceFile[],
+): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!EXCLUDE_DIRS.has(entry.name)) {
+        await walkDir(path.join(dir, entry.name), bisonFiles, flexFiles);
+      }
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name).toLowerCase();
+      const fsPath = path.join(dir, entry.name);
+      const uri = URI.file(fsPath).toString();
+
+      if (BISON_EXTENSIONS.has(ext)) {
+        bisonFiles.push({ uri, fsPath, language: 'bison' });
+      } else if (FLEX_EXTENSIONS.has(ext)) {
+        flexFiles.push({ uri, fsPath, language: 'flex' });
+      }
+    }
+  }
+}
+
+async function findBuildSystems(workspaceRoot: string): Promise<BuildSystemInfo[]> {
+  const results: BuildSystemInfo[] = [];
+
+  const checkFile = async (filePath: string, kind: BuildSystemInfo['kind']): Promise<void> => {
+    try {
+      await fs.promises.access(filePath);
+      results.push({ kind, configFile: filePath });
+    } catch {
+      // not found
+    }
+  };
+
+  await checkFile(path.join(workspaceRoot, 'CMakeLists.txt'), 'cmake');
+  await checkFile(path.join(workspaceRoot, 'Makefile'), 'make');
+  await checkFile(path.join(workspaceRoot, 'configure.ac'), 'automake');
+  await checkFile(path.join(workspaceRoot, 'Makefile.am'), 'automake');
+
+  // Also check immediate subdirectories (depth 1)
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(workspaceRoot, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && !EXCLUDE_DIRS.has(entry.name)) {
+      const subDir = path.join(workspaceRoot, entry.name);
+      await checkFile(path.join(subDir, 'CMakeLists.txt'), 'cmake');
+    }
+  }
+
+  return results;
+}
+
+function normalizeStem(name: string): string {
+  let stem = path.basename(name, path.extname(name)).toLowerCase();
+  for (const suffix of STEM_SUFFIXES) {
+    if (stem.endsWith(suffix)) {
+      stem = stem.slice(0, -suffix.length);
+      break;
+    }
+  }
+  return stem;
+}
+
+async function detectExplicitPairs(
+  buildSystems: BuildSystemInfo[],
+  bisonFiles: BisonSourceFile[],
+  flexFiles: FlexSourceFile[],
+): Promise<ParserScannerPair[]> {
+  const pairs: ParserScannerPair[] = [];
+
+  for (const bs of buildSystems) {
+    if (bs.kind !== 'cmake') continue;
+
+    let content: string;
+    try {
+      content = await fs.promises.readFile(bs.configFile, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    // Match BISON_TARGET and FLEX_TARGET names, then add_flex_bison_dependency
+    const bisonTargetRe = /BISON_TARGET\s*\(\s*\w+\s+([^\s)]+)/g;
+    const flexTargetRe = /FLEX_TARGET\s*\(\s*\w+\s+([^\s)]+)/g;
+    const depRe = /add_flex_bison_dependency\s*\(\s*(\w+)\s+(\w+)\s*\)/g;
+
+    const cmakeDir = path.dirname(bs.configFile);
+
+    // Build maps of CMake target name → source file
+    const bisonTargetMap = new Map<string, string>();
+    const flexTargetMap = new Map<string, string>();
+
+    let m: RegExpExecArray | null;
+
+    const bisonNameRe = /BISON_TARGET\s*\(\s*(\w+)\s+([^\s)]+)/g;
+    while ((m = bisonNameRe.exec(content)) !== null) {
+      const targetName = m[1];
+      const srcFile = path.resolve(cmakeDir, m[2]);
+      bisonTargetMap.set(targetName, srcFile);
+    }
+
+    const flexNameRe = /FLEX_TARGET\s*\(\s*(\w+)\s+([^\s)]+)/g;
+    while ((m = flexNameRe.exec(content)) !== null) {
+      const targetName = m[1];
+      const srcFile = path.resolve(cmakeDir, m[2]);
+      flexTargetMap.set(targetName, srcFile);
+    }
+
+    // add_flex_bison_dependency(FLEX_TARGET BISON_TARGET)
+    while ((m = depRe.exec(content)) !== null) {
+      const flexName = m[1];
+      const bisonName = m[2];
+      const flexSrc = flexTargetMap.get(flexName);
+      const bisonSrc = bisonTargetMap.get(bisonName);
+      if (!flexSrc || !bisonSrc) continue;
+
+      const bison = bisonFiles.find(f => path.resolve(f.fsPath) === path.resolve(bisonSrc));
+      const flex = flexFiles.find(f => path.resolve(f.fsPath) === path.resolve(flexSrc));
+      if (bison && flex) {
+        pairs.push({ parser: bison, scanner: flex, confidence: 'explicit' });
+      }
+    }
+
+    // Fallback: match by stem if same CMakeLists.txt declares both
+    bisonTargetRe.lastIndex = 0;
+    flexTargetRe.lastIndex = 0;
+    const cmakeBisonSrcs: string[] = [];
+    const cmakeFlexSrcs: string[] = [];
+
+    while ((m = bisonTargetRe.exec(content)) !== null) {
+      cmakeBisonSrcs.push(path.resolve(cmakeDir, m[1]));
+    }
+    while ((m = flexTargetRe.exec(content)) !== null) {
+      cmakeFlexSrcs.push(path.resolve(cmakeDir, m[1]));
+    }
+
+    for (const bSrc of cmakeBisonSrcs) {
+      for (const fSrc of cmakeFlexSrcs) {
+        const alreadyPaired = pairs.some(
+          p => p.parser.fsPath === bSrc || p.scanner.fsPath === fSrc,
+        );
+        if (alreadyPaired) continue;
+
+        if (normalizeStem(bSrc) === normalizeStem(fSrc)) {
+          const bison = bisonFiles.find(f => path.resolve(f.fsPath) === bSrc);
+          const flex = flexFiles.find(f => path.resolve(f.fsPath) === fSrc);
+          if (bison && flex) {
+            pairs.push({ parser: bison, scanner: flex, confidence: 'explicit' });
+          }
+        }
+      }
+    }
+  }
+
+  return pairs;
+}
+
+function detectInferredPairs(
+  bisonFiles: BisonSourceFile[],
+  flexFiles: FlexSourceFile[],
+  explicitPairs: ParserScannerPair[],
+): ParserScannerPair[] {
+  const pairs: ParserScannerPair[] = [];
+  const pairedBison = new Set(explicitPairs.map(p => p.parser.uri));
+  const pairedFlex = new Set(explicitPairs.map(p => p.scanner.uri));
+
+  for (const bison of bisonFiles) {
+    if (pairedBison.has(bison.uri)) continue;
+    const bStem = normalizeStem(bison.fsPath);
+
+    for (const flex of flexFiles) {
+      if (pairedFlex.has(flex.uri)) continue;
+      const fStem = normalizeStem(flex.fsPath);
+
+      if (bStem === fStem && bStem !== '') {
+        pairs.push({ parser: bison, scanner: flex, confidence: 'inferred' });
+        pairedBison.add(bison.uri);
+        pairedFlex.add(flex.uri);
+        break;
+      }
+    }
+  }
+
+  return pairs;
+}
+
+async function detectGeneratedFiles(
+  bisonFiles: BisonSourceFile[],
+  flexFiles: FlexSourceFile[],
+): Promise<GeneratedFile[]> {
+  const generated: GeneratedFile[] = [];
+
+  for (const bison of bisonFiles) {
+    const dir = bison.buildDirectory ?? path.dirname(bison.fsPath);
+    const stem = path.basename(bison.fsPath, path.extname(bison.fsPath));
+
+    const candidates: Array<{ file: string; kind: GeneratedFile['kind'] }> = [
+      { file: path.join(dir, `${stem}.tab.c`), kind: 'tab.c' },
+      { file: path.join(dir, `${stem}.tab.cpp`), kind: 'tab.cpp' },
+      { file: path.join(dir, `${stem}.tab.h`), kind: 'tab.h' },
+      { file: path.join(dir, `${stem}.tab.hpp`), kind: 'tab.h' },
+      { file: path.join(dir, `${stem}.output`), kind: 'output' },
+      { file: path.join(dir, `${stem}.xml`), kind: 'xml' },
+      { file: path.join(dir, `${stem}.gv`), kind: 'gv' },
+    ];
+
+    for (const { file, kind } of candidates) {
+      try {
+        await fs.promises.access(file);
+        generated.push({ uri: URI.file(file).toString(), fsPath: file, kind, sourceUri: bison.uri });
+      } catch {
+        // not found
+      }
+    }
+  }
+
+  for (const flex of flexFiles) {
+    const dir = path.dirname(flex.fsPath);
+    const stem = path.basename(flex.fsPath, path.extname(flex.fsPath));
+
+    const candidates: Array<{ file: string; kind: GeneratedFile['kind'] }> = [
+      { file: path.join(dir, 'lex.yy.c'), kind: 'lex.yy.c' },
+      { file: path.join(dir, 'lex.yy.cpp'), kind: 'lex.yy.cpp' },
+      { file: path.join(dir, `${stem}.yy.cpp`), kind: 'lex.yy.cpp' },
+    ];
+
+    for (const { file, kind } of candidates) {
+      try {
+        await fs.promises.access(file);
+        generated.push({ uri: URI.file(file).toString(), fsPath: file, kind, sourceUri: flex.uri });
+      } catch {
+        // not found
+      }
+    }
+  }
+
+  return generated;
+}
+
+export async function scanWorkspace(workspaceFolders: string[]): Promise<BisonFlexProjectModel> {
+  const bisonFiles: BisonSourceFile[] = [];
+  const flexFiles: FlexSourceFile[] = [];
+  const buildSystems: BuildSystemInfo[] = [];
+
+  const workspaceRoot = workspaceFolders[0] ?? '';
+
+  for (const folder of workspaceFolders) {
+    await walkDir(folder, bisonFiles, flexFiles);
+    const bs = await findBuildSystems(folder);
+    buildSystems.push(...bs);
+  }
+
+  const explicitPairs = await detectExplicitPairs(buildSystems, bisonFiles, flexFiles);
+  const inferredPairs = detectInferredPairs(bisonFiles, flexFiles, explicitPairs);
+  const pairs = [...explicitPairs, ...inferredPairs];
+
+  const generatedFiles = await detectGeneratedFiles(bisonFiles, flexFiles);
+
+  return {
+    workspaceRoot,
+    parsers: bisonFiles,
+    scanners: flexFiles,
+    pairs,
+    generatedFiles,
+    buildSystems,
+    lastScanned: Date.now(),
+  };
+}

--- a/server/src/project/projectScanner.ts
+++ b/server/src/project/projectScanner.ts
@@ -157,6 +157,8 @@ export function generatedCandidates(
       // Automake style (underscore separator)
       { file: path.join(dir, 'lex_yy.c'), kind: 'lex.yy.c' },
       { file: path.join(dir, 'lex_yy.cpp'), kind: 'lex.yy.cpp' },
+      { file: path.join(dir, 'lex._.c'), kind: 'lex.yy.c' },
+      { file: path.join(dir, 'lex._.cpp'), kind: 'lex.yy.cpp' },
     ];
   }
 }

--- a/server/src/project/projectScanner.ts
+++ b/server/src/project/projectScanner.ts
@@ -151,9 +151,12 @@ export function generatedCandidates(
       { file: path.join(dir, 'lex.yy.c'), kind: 'lex.yy.c' },
       { file: path.join(dir, 'lex.yy.cpp'), kind: 'lex.yy.cpp' },
       { file: path.join(dir, `${stem}.yy.cpp`), kind: 'lex.yy.cpp' },
-      // Automake style
+      // Automake style (dot separator, per-scanner prefix)
       { file: path.join(dir, `lex.${stem}.c`), kind: 'lex.yy.c' },
       { file: path.join(dir, `lex.${stem}.cpp`), kind: 'lex.yy.cpp' },
+      // Automake style (underscore separator)
+      { file: path.join(dir, 'lex_yy.c'), kind: 'lex.yy.c' },
+      { file: path.join(dir, 'lex_yy.cpp'), kind: 'lex.yy.cpp' },
     ];
   }
 }

--- a/server/src/project/projectScanner.ts
+++ b/server/src/project/projectScanner.ts
@@ -12,16 +12,157 @@ import {
 
 const EXCLUDE_DIRS = new Set(['node_modules', 'dist', '.git', 'vendor']);
 
-const BISON_EXTENSIONS = new Set(['.y', '.yy']);
-const FLEX_EXTENSIONS = new Set(['.l', '.ll']);
+const BISON_EXTENSIONS = new Set(['.y', '.yy', '.ypp', '.bison']);
+const FLEX_EXTENSIONS = new Set(['.l', '.ll', '.lex', '.flex']);
 
 const STEM_SUFFIXES = [
   '_parser', '_scanner', '-parser', '-scanner',
   'parser', 'scanner', '_lex', '_tab',
 ];
 
+// ─── Pure exported functions ─────────────────────────────────────────────────
+
+export function normalizeStem(name: string): string {
+  let stem = path.basename(name, path.extname(name)).toLowerCase();
+  for (const suffix of STEM_SUFFIXES) {
+    if (stem.endsWith(suffix) && stem.length > suffix.length) {
+      stem = stem.slice(0, -suffix.length);
+      break;
+    }
+  }
+  return stem;
+}
+
+export function detectPairsFromPaths(
+  bisonPaths: string[],
+  flexPaths: string[],
+): Array<{ bisonPath: string; flexPath: string; source: 'basename' | 'normalized-stem'; reason: string }> {
+  const pairs: Array<{ bisonPath: string; flexPath: string; source: 'basename' | 'normalized-stem'; reason: string }> = [];
+  const pairedBison = new Set<string>();
+  const pairedFlex = new Set<string>();
+
+  // Pass 1 — identical basename (no extension)
+  for (const bPath of bisonPaths) {
+    const bBase = path.basename(bPath, path.extname(bPath));
+    for (const fPath of flexPaths) {
+      const fBase = path.basename(fPath, path.extname(fPath));
+      if (bBase === fBase) {
+        pairs.push({
+          bisonPath: bPath,
+          flexPath: fPath,
+          source: 'basename',
+          reason: `same basename "${bBase}"`,
+        });
+        pairedBison.add(bPath);
+        pairedFlex.add(fPath);
+        break;
+      }
+    }
+  }
+
+  // Pass 2 — normalized stem (suffix stripping)
+  for (const bPath of bisonPaths) {
+    if (pairedBison.has(bPath)) continue;
+    const bStem = normalizeStem(bPath);
+    if (!bStem) continue;
+
+    for (const fPath of flexPaths) {
+      if (pairedFlex.has(fPath)) continue;
+      const fStem = normalizeStem(fPath);
+      if (bStem === fStem) {
+        const bBase = path.basename(bPath, path.extname(bPath));
+        const fBase = path.basename(fPath, path.extname(fPath));
+        pairs.push({
+          bisonPath: bPath,
+          flexPath: fPath,
+          source: 'normalized-stem',
+          reason: `normalized stem "${bStem}" from "${bBase}" and "${fBase}"`,
+        });
+        pairedBison.add(bPath);
+        pairedFlex.add(fPath);
+        break;
+      }
+    }
+  }
+
+  return pairs;
+}
+
+export function parseCmakePairs(
+  content: string,
+): Array<{ bisonFile: string; flexFile: string }> {
+  const bisonTargets = new Map<string, string>(); // target name (upper) → file
+  const flexTargets = new Map<string, string>();
+
+  const bisonTargetRe = /BISON_TARGET\s*\(\s*(\w+)\s+(\S+)/gi;
+  const flexTargetRe = /FLEX_TARGET\s*\(\s*(\w+)\s+(\S+)/gi;
+  const depRe = /ADD_FLEX_BISON_DEPENDENCY\s*\(\s*(\w+)\s+(\w+)\s*\)/gi;
+
+  let m: RegExpExecArray | null;
+
+  while ((m = bisonTargetRe.exec(content)) !== null) {
+    bisonTargets.set(m[1].toUpperCase(), m[2]);
+  }
+  while ((m = flexTargetRe.exec(content)) !== null) {
+    flexTargets.set(m[1].toUpperCase(), m[2]);
+  }
+
+  const pairs: Array<{ bisonFile: string; flexFile: string }> = [];
+  while ((m = depRe.exec(content)) !== null) {
+    const flexName = m[1].toUpperCase();
+    const bisonName = m[2].toUpperCase();
+    const flexFile = flexTargets.get(flexName);
+    const bisonFile = bisonTargets.get(bisonName);
+    if (flexFile && bisonFile) {
+      pairs.push({ bisonFile, flexFile });
+    }
+  }
+
+  return pairs;
+}
+
+export function generatedCandidates(
+  sourcePath: string,
+  buildDir: string | undefined,
+  lang: 'bison' | 'flex',
+): Array<{ file: string; kind: GeneratedFile['kind'] }> {
+  const dir = buildDir ?? path.dirname(sourcePath);
+  const stem = path.basename(sourcePath, path.extname(sourcePath));
+
+  if (lang === 'bison') {
+    return [
+      // GNU style
+      { file: path.join(dir, `${stem}.tab.c`), kind: 'tab.c' },
+      { file: path.join(dir, `${stem}.tab.cpp`), kind: 'tab.cpp' },
+      { file: path.join(dir, `${stem}.tab.h`), kind: 'tab.h' },
+      { file: path.join(dir, `${stem}.tab.hpp`), kind: 'tab.h' },
+      { file: path.join(dir, `${stem}.output`), kind: 'output' },
+      { file: path.join(dir, `${stem}.xml`), kind: 'xml' },
+      { file: path.join(dir, `${stem}.gv`), kind: 'gv' },
+      // Automake style
+      { file: path.join(dir, `${stem}_tab.c`), kind: 'tab.c' },
+      { file: path.join(dir, `${stem}_tab.cpp`), kind: 'tab.cpp' },
+      { file: path.join(dir, `${stem}_tab.h`), kind: 'tab.h' },
+      { file: path.join(dir, `${stem}_tab.hpp`), kind: 'tab.h' },
+    ];
+  } else {
+    return [
+      // GNU style
+      { file: path.join(dir, 'lex.yy.c'), kind: 'lex.yy.c' },
+      { file: path.join(dir, 'lex.yy.cpp'), kind: 'lex.yy.cpp' },
+      { file: path.join(dir, `${stem}.yy.cpp`), kind: 'lex.yy.cpp' },
+      // Automake style
+      { file: path.join(dir, `lex.${stem}.c`), kind: 'lex.yy.c' },
+      { file: path.join(dir, `lex.${stem}.cpp`), kind: 'lex.yy.cpp' },
+    ];
+  }
+}
+
+// ─── Internal scan helpers ───────────────────────────────────────────────────
+
 async function walkDir(
   dir: string,
+  root: string,
   bisonFiles: BisonSourceFile[],
   flexFiles: FlexSourceFile[],
 ): Promise<void> {
@@ -35,17 +176,18 @@ async function walkDir(
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (!EXCLUDE_DIRS.has(entry.name)) {
-        await walkDir(path.join(dir, entry.name), bisonFiles, flexFiles);
+        await walkDir(path.join(dir, entry.name), root, bisonFiles, flexFiles);
       }
     } else if (entry.isFile()) {
       const ext = path.extname(entry.name).toLowerCase();
       const fsPath = path.join(dir, entry.name);
       const uri = URI.file(fsPath).toString();
+      const relativePath = path.relative(root, fsPath);
 
       if (BISON_EXTENSIONS.has(ext)) {
-        bisonFiles.push({ uri, fsPath, language: 'bison' });
+        bisonFiles.push({ uri, fsPath, language: 'bison', workspaceRoot: root, relativePath });
       } else if (FLEX_EXTENSIONS.has(ext)) {
-        flexFiles.push({ uri, fsPath, language: 'flex' });
+        flexFiles.push({ uri, fsPath, language: 'flex', workspaceRoot: root, relativePath });
       }
     }
   }
@@ -54,7 +196,7 @@ async function walkDir(
 async function findBuildSystems(workspaceRoot: string): Promise<BuildSystemInfo[]> {
   const results: BuildSystemInfo[] = [];
 
-  const checkFile = async (filePath: string, kind: BuildSystemInfo['kind']): Promise<void> => {
+  const tryAdd = async (filePath: string, kind: BuildSystemInfo['kind']): Promise<void> => {
     try {
       await fs.promises.access(filePath);
       results.push({ kind, configFile: filePath });
@@ -63,12 +205,11 @@ async function findBuildSystems(workspaceRoot: string): Promise<BuildSystemInfo[
     }
   };
 
-  await checkFile(path.join(workspaceRoot, 'CMakeLists.txt'), 'cmake');
-  await checkFile(path.join(workspaceRoot, 'Makefile'), 'make');
-  await checkFile(path.join(workspaceRoot, 'configure.ac'), 'automake');
-  await checkFile(path.join(workspaceRoot, 'Makefile.am'), 'automake');
+  await tryAdd(path.join(workspaceRoot, 'CMakeLists.txt'), 'cmake');
+  await tryAdd(path.join(workspaceRoot, 'Makefile'), 'make');
+  await tryAdd(path.join(workspaceRoot, 'configure.ac'), 'automake');
+  await tryAdd(path.join(workspaceRoot, 'Makefile.am'), 'automake');
 
-  // Also check immediate subdirectories (depth 1)
   let entries: fs.Dirent[];
   try {
     entries = await fs.promises.readdir(workspaceRoot, { withFileTypes: true });
@@ -78,23 +219,11 @@ async function findBuildSystems(workspaceRoot: string): Promise<BuildSystemInfo[
 
   for (const entry of entries) {
     if (entry.isDirectory() && !EXCLUDE_DIRS.has(entry.name)) {
-      const subDir = path.join(workspaceRoot, entry.name);
-      await checkFile(path.join(subDir, 'CMakeLists.txt'), 'cmake');
+      await tryAdd(path.join(workspaceRoot, entry.name, 'CMakeLists.txt'), 'cmake');
     }
   }
 
   return results;
-}
-
-function normalizeStem(name: string): string {
-  let stem = path.basename(name, path.extname(name)).toLowerCase();
-  for (const suffix of STEM_SUFFIXES) {
-    if (stem.endsWith(suffix)) {
-      stem = stem.slice(0, -suffix.length);
-      break;
-    }
-  }
-  return stem;
 }
 
 async function detectExplicitPairs(
@@ -114,75 +243,24 @@ async function detectExplicitPairs(
       continue;
     }
 
-    // Match BISON_TARGET and FLEX_TARGET names, then add_flex_bison_dependency
-    const bisonTargetRe = /BISON_TARGET\s*\(\s*\w+\s+([^\s)]+)/g;
-    const flexTargetRe = /FLEX_TARGET\s*\(\s*\w+\s+([^\s)]+)/g;
-    const depRe = /add_flex_bison_dependency\s*\(\s*(\w+)\s+(\w+)\s*\)/g;
-
     const cmakeDir = path.dirname(bs.configFile);
+    const rawPairs = parseCmakePairs(content);
 
-    // Build maps of CMake target name → source file
-    const bisonTargetMap = new Map<string, string>();
-    const flexTargetMap = new Map<string, string>();
+    for (const raw of rawPairs) {
+      const bisonAbs = path.resolve(cmakeDir, raw.bisonFile);
+      const flexAbs = path.resolve(cmakeDir, raw.flexFile);
 
-    let m: RegExpExecArray | null;
+      const bison = bisonFiles.find(f => path.resolve(f.fsPath) === bisonAbs);
+      const flex = flexFiles.find(f => path.resolve(f.fsPath) === flexAbs);
 
-    const bisonNameRe = /BISON_TARGET\s*\(\s*(\w+)\s+([^\s)]+)/g;
-    while ((m = bisonNameRe.exec(content)) !== null) {
-      const targetName = m[1];
-      const srcFile = path.resolve(cmakeDir, m[2]);
-      bisonTargetMap.set(targetName, srcFile);
-    }
-
-    const flexNameRe = /FLEX_TARGET\s*\(\s*(\w+)\s+([^\s)]+)/g;
-    while ((m = flexNameRe.exec(content)) !== null) {
-      const targetName = m[1];
-      const srcFile = path.resolve(cmakeDir, m[2]);
-      flexTargetMap.set(targetName, srcFile);
-    }
-
-    // add_flex_bison_dependency(FLEX_TARGET BISON_TARGET)
-    while ((m = depRe.exec(content)) !== null) {
-      const flexName = m[1];
-      const bisonName = m[2];
-      const flexSrc = flexTargetMap.get(flexName);
-      const bisonSrc = bisonTargetMap.get(bisonName);
-      if (!flexSrc || !bisonSrc) continue;
-
-      const bison = bisonFiles.find(f => path.resolve(f.fsPath) === path.resolve(bisonSrc));
-      const flex = flexFiles.find(f => path.resolve(f.fsPath) === path.resolve(flexSrc));
       if (bison && flex) {
-        pairs.push({ parser: bison, scanner: flex, confidence: 'explicit' });
-      }
-    }
-
-    // Fallback: match by stem if same CMakeLists.txt declares both
-    bisonTargetRe.lastIndex = 0;
-    flexTargetRe.lastIndex = 0;
-    const cmakeBisonSrcs: string[] = [];
-    const cmakeFlexSrcs: string[] = [];
-
-    while ((m = bisonTargetRe.exec(content)) !== null) {
-      cmakeBisonSrcs.push(path.resolve(cmakeDir, m[1]));
-    }
-    while ((m = flexTargetRe.exec(content)) !== null) {
-      cmakeFlexSrcs.push(path.resolve(cmakeDir, m[1]));
-    }
-
-    for (const bSrc of cmakeBisonSrcs) {
-      for (const fSrc of cmakeFlexSrcs) {
-        const alreadyPaired = pairs.some(
-          p => p.parser.fsPath === bSrc || p.scanner.fsPath === fSrc,
-        );
-        if (alreadyPaired) continue;
-
-        if (normalizeStem(bSrc) === normalizeStem(fSrc)) {
-          const bison = bisonFiles.find(f => path.resolve(f.fsPath) === bSrc);
-          const flex = flexFiles.find(f => path.resolve(f.fsPath) === fSrc);
-          if (bison && flex) {
-            pairs.push({ parser: bison, scanner: flex, confidence: 'explicit' });
-          }
-        }
+        pairs.push({
+          parser: bison,
+          scanner: flex,
+          confidence: 'explicit',
+          source: 'cmake',
+          reason: `ADD_FLEX_BISON_DEPENDENCY in ${path.relative(bison.workspaceRoot, bs.configFile)}`,
+        });
       }
     }
   }
@@ -190,33 +268,33 @@ async function detectExplicitPairs(
   return pairs;
 }
 
-function detectInferredPairs(
+function buildInferredPairs(
   bisonFiles: BisonSourceFile[],
   flexFiles: FlexSourceFile[],
   explicitPairs: ParserScannerPair[],
 ): ParserScannerPair[] {
-  const pairs: ParserScannerPair[] = [];
-  const pairedBison = new Set(explicitPairs.map(p => p.parser.uri));
-  const pairedFlex = new Set(explicitPairs.map(p => p.scanner.uri));
+  const pairedBisonUris = new Set(explicitPairs.map(p => p.parser.uri));
+  const pairedFlexUris = new Set(explicitPairs.map(p => p.scanner.uri));
 
-  for (const bison of bisonFiles) {
-    if (pairedBison.has(bison.uri)) continue;
-    const bStem = normalizeStem(bison.fsPath);
+  const unpairedBison = bisonFiles.filter(f => !pairedBisonUris.has(f.uri));
+  const unpairedFlex = flexFiles.filter(f => !pairedFlexUris.has(f.uri));
 
-    for (const flex of flexFiles) {
-      if (pairedFlex.has(flex.uri)) continue;
-      const fStem = normalizeStem(flex.fsPath);
+  const rawPairs = detectPairsFromPaths(
+    unpairedBison.map(f => f.fsPath),
+    unpairedFlex.map(f => f.fsPath),
+  );
 
-      if (bStem === fStem && bStem !== '') {
-        pairs.push({ parser: bison, scanner: flex, confidence: 'inferred' });
-        pairedBison.add(bison.uri);
-        pairedFlex.add(flex.uri);
-        break;
-      }
-    }
-  }
-
-  return pairs;
+  return rawPairs.map(raw => {
+    const bison = unpairedBison.find(f => f.fsPath === raw.bisonPath)!;
+    const flex = unpairedFlex.find(f => f.fsPath === raw.flexPath)!;
+    return {
+      parser: bison,
+      scanner: flex,
+      confidence: 'inferred' as const,
+      source: raw.source,
+      reason: raw.reason,
+    };
+  });
 }
 
 async function detectGeneratedFiles(
@@ -226,20 +304,7 @@ async function detectGeneratedFiles(
   const generated: GeneratedFile[] = [];
 
   for (const bison of bisonFiles) {
-    const dir = bison.buildDirectory ?? path.dirname(bison.fsPath);
-    const stem = path.basename(bison.fsPath, path.extname(bison.fsPath));
-
-    const candidates: Array<{ file: string; kind: GeneratedFile['kind'] }> = [
-      { file: path.join(dir, `${stem}.tab.c`), kind: 'tab.c' },
-      { file: path.join(dir, `${stem}.tab.cpp`), kind: 'tab.cpp' },
-      { file: path.join(dir, `${stem}.tab.h`), kind: 'tab.h' },
-      { file: path.join(dir, `${stem}.tab.hpp`), kind: 'tab.h' },
-      { file: path.join(dir, `${stem}.output`), kind: 'output' },
-      { file: path.join(dir, `${stem}.xml`), kind: 'xml' },
-      { file: path.join(dir, `${stem}.gv`), kind: 'gv' },
-    ];
-
-    for (const { file, kind } of candidates) {
+    for (const { file, kind } of generatedCandidates(bison.fsPath, bison.buildDirectory, 'bison')) {
       try {
         await fs.promises.access(file);
         generated.push({ uri: URI.file(file).toString(), fsPath: file, kind, sourceUri: bison.uri });
@@ -250,16 +315,7 @@ async function detectGeneratedFiles(
   }
 
   for (const flex of flexFiles) {
-    const dir = path.dirname(flex.fsPath);
-    const stem = path.basename(flex.fsPath, path.extname(flex.fsPath));
-
-    const candidates: Array<{ file: string; kind: GeneratedFile['kind'] }> = [
-      { file: path.join(dir, 'lex.yy.c'), kind: 'lex.yy.c' },
-      { file: path.join(dir, 'lex.yy.cpp'), kind: 'lex.yy.cpp' },
-      { file: path.join(dir, `${stem}.yy.cpp`), kind: 'lex.yy.cpp' },
-    ];
-
-    for (const { file, kind } of candidates) {
+    for (const { file, kind } of generatedCandidates(flex.fsPath, undefined, 'flex')) {
       try {
         await fs.promises.access(file);
         generated.push({ uri: URI.file(file).toString(), fsPath: file, kind, sourceUri: flex.uri });
@@ -272,6 +328,8 @@ async function detectGeneratedFiles(
   return generated;
 }
 
+// ─── Public scan entry point ─────────────────────────────────────────────────
+
 export async function scanWorkspace(workspaceFolders: string[]): Promise<BisonFlexProjectModel> {
   const bisonFiles: BisonSourceFile[] = [];
   const flexFiles: FlexSourceFile[] = [];
@@ -280,13 +338,13 @@ export async function scanWorkspace(workspaceFolders: string[]): Promise<BisonFl
   const workspaceRoot = workspaceFolders[0] ?? '';
 
   for (const folder of workspaceFolders) {
-    await walkDir(folder, bisonFiles, flexFiles);
+    await walkDir(folder, folder, bisonFiles, flexFiles);
     const bs = await findBuildSystems(folder);
     buildSystems.push(...bs);
   }
 
   const explicitPairs = await detectExplicitPairs(buildSystems, bisonFiles, flexFiles);
-  const inferredPairs = detectInferredPairs(bisonFiles, flexFiles, explicitPairs);
+  const inferredPairs = buildInferredPairs(bisonFiles, flexFiles, explicitPairs);
   const pairs = [...explicitPairs, ...inferredPairs];
 
   const generatedFiles = await detectGeneratedFiles(bisonFiles, flexFiles);

--- a/server/src/project/projectTypes.ts
+++ b/server/src/project/projectTypes.ts
@@ -12,6 +12,8 @@ export interface BisonSourceFile {
   uri: string;
   fsPath: string;
   language: 'bison';
+  workspaceRoot: string;
+  relativePath: string;
   buildDirectory?: string;
   outputFile?: string;
 }
@@ -20,12 +22,16 @@ export interface FlexSourceFile {
   uri: string;
   fsPath: string;
   language: 'flex' | 'reflex';
+  workspaceRoot: string;
+  relativePath: string;
 }
 
 export interface ParserScannerPair {
   parser: BisonSourceFile;
   scanner: FlexSourceFile;
   confidence: 'explicit' | 'inferred';
+  source: 'cmake' | 'basename' | 'normalized-stem';
+  reason: string;
 }
 
 export interface GeneratedFile {

--- a/server/src/project/projectTypes.ts
+++ b/server/src/project/projectTypes.ts
@@ -1,0 +1,42 @@
+export interface BisonFlexProjectModel {
+  workspaceRoot: string;
+  parsers: BisonSourceFile[];
+  scanners: FlexSourceFile[];
+  pairs: ParserScannerPair[];
+  generatedFiles: GeneratedFile[];
+  buildSystems: BuildSystemInfo[];
+  lastScanned: number;
+}
+
+export interface BisonSourceFile {
+  uri: string;
+  fsPath: string;
+  language: 'bison';
+  buildDirectory?: string;
+  outputFile?: string;
+}
+
+export interface FlexSourceFile {
+  uri: string;
+  fsPath: string;
+  language: 'flex' | 'reflex';
+}
+
+export interface ParserScannerPair {
+  parser: BisonSourceFile;
+  scanner: FlexSourceFile;
+  confidence: 'explicit' | 'inferred';
+}
+
+export interface GeneratedFile {
+  uri: string;
+  fsPath: string;
+  kind: 'tab.c' | 'tab.cpp' | 'tab.h' | 'lex.yy.c' | 'lex.yy.cpp' | 'output' | 'xml' | 'gv';
+  sourceUri: string;
+}
+
+export interface BuildSystemInfo {
+  kind: 'cmake' | 'make' | 'automake' | 'unknown';
+  configFile: string;
+  buildDirectory?: string;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -47,12 +47,15 @@ import { getWorkspaceSymbols } from './providers/workspaceSymbols';
 import { getCodeLenses } from './providers/codeLens';
 import { computeCmakeDiagnostic } from './providers/cmake';
 import { ExtensionSettings, DEFAULT_SETTINGS } from './providers/settings';
+import { WorkspaceIndex } from './project/projectModel';
 
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments(TextDocument);
 
 // Cache of parsed documents
 const documentModels = new Map<string, DocumentModel>();
+
+let workspaceIndex: WorkspaceIndex | undefined;
 
 connection.onInitialize((_params: InitializeParams): InitializeResult => {
   return {
@@ -77,6 +80,15 @@ connection.onInitialize((_params: InitializeParams): InitializeResult => {
       codeLensProvider: { resolveProvider: false },
     },
   };
+});
+
+connection.onInitialized(async () => {
+  const folders = (await connection.workspace.getWorkspaceFolders()) ?? [];
+  const roots = folders.map(f => URI.parse(f.uri).fsPath);
+  if (roots.length > 0) {
+    workspaceIndex = new WorkspaceIndex(roots[0]);
+    void workspaceIndex.initialize(roots);
+  }
 });
 
 // Revalidate on document change

--- a/tests/test-project-model.ts
+++ b/tests/test-project-model.ts
@@ -1,0 +1,251 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import {
+  normalizeStem,
+  detectPairsFromPaths,
+  parseCmakePairs,
+  generatedCandidates,
+} from '../server/src/project/projectScanner';
+import { WorkspaceIndex } from '../server/src/project/projectModel';
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  try {
+    const result = fn();
+    if (result && typeof (result as Promise<void>).then === 'function') {
+      (result as Promise<void>).then(() => {
+        console.log(`  [PASS] ${name}`);
+        passed++;
+      }).catch((e: unknown) => {
+        console.error(`  [FAIL] ${name}: ${e}`);
+        failed++;
+      });
+    } else {
+      console.log(`  [PASS] ${name}`);
+      passed++;
+    }
+  } catch (e) {
+    console.error(`  [FAIL] ${name}: ${e}`);
+    failed++;
+  }
+}
+
+// ─── normalizeStem ────────────────────────────────────────────────────────────
+
+console.log('\nnormalizeStem');
+
+test('plain stem unchanged', () => {
+  assert.strictEqual(normalizeStem('calc.y'), 'calc');
+});
+
+test('strips _parser suffix', () => {
+  assert.strictEqual(normalizeStem('sql_parser.y'), 'sql');
+});
+
+test('strips _scanner suffix', () => {
+  assert.strictEqual(normalizeStem('sql_scanner.l'), 'sql');
+});
+
+test('strips -parser suffix', () => {
+  assert.strictEqual(normalizeStem('json-parser.yy'), 'json');
+});
+
+test('strips _lex suffix', () => {
+  assert.strictEqual(normalizeStem('calc_lex.l'), 'calc');
+});
+
+test('strips _tab suffix', () => {
+  assert.strictEqual(normalizeStem('calc_tab.c'), 'calc');
+});
+
+test('full path: extracts and normalizes', () => {
+  assert.strictEqual(normalizeStem('/project/src/sql_parser.y'), 'sql');
+});
+
+test('no suffix to strip stays as-is', () => {
+  assert.strictEqual(normalizeStem('myfile.y'), 'myfile');
+});
+
+// ─── detectPairsFromPaths: same basename ─────────────────────────────────────
+
+console.log('\ndetectPairsFromPaths — same basename');
+
+test('same basename pairs (source = basename)', () => {
+  const result = detectPairsFromPaths(['/a/calc.y'], ['/b/calc.l']);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].source, 'basename');
+  assert.ok(result[0].reason.includes('calc'), `reason: ${result[0].reason}`);
+  assert.strictEqual(result[0].bisonPath, '/a/calc.y');
+  assert.strictEqual(result[0].flexPath, '/b/calc.l');
+});
+
+test('same basename with different extensions (.yy / .ll)', () => {
+  const result = detectPairsFromPaths(['/a/json.yy'], ['/b/json.ll']);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].source, 'basename');
+});
+
+// ─── detectPairsFromPaths: normalized stem ───────────────────────────────────
+
+console.log('\ndetectPairsFromPaths — normalized stem');
+
+test('sql_parser.y + sql_scanner.l → normalized-stem pair', () => {
+  const result = detectPairsFromPaths(['/a/sql_parser.y'], ['/b/sql_scanner.l']);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].source, 'normalized-stem');
+  assert.ok(result[0].reason.includes('sql'), `reason: ${result[0].reason}`);
+});
+
+
+// ─── detectPairsFromPaths: no unrelated pair ─────────────────────────────────
+
+console.log('\ndetectPairsFromPaths — no unrelated pair');
+
+test('foo.y + bar.l → no pair', () => {
+  const result = detectPairsFromPaths(['/a/foo.y'], ['/b/bar.l']);
+  assert.strictEqual(result.length, 0);
+});
+
+test('multiple files — only matching stems paired', () => {
+  const result = detectPairsFromPaths(
+    ['/a/calc.y', '/a/xml.y'],
+    ['/b/calc.l', '/b/json.l'],
+  );
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].bisonPath, '/a/calc.y');
+  assert.strictEqual(result[0].flexPath, '/b/calc.l');
+});
+
+// ─── parseCmakePairs ─────────────────────────────────────────────────────────
+
+console.log('\nparseCmakePairs');
+
+const cmakeUppercase = [
+  'BISON_TARGET(MyParser parser.y output/parser.tab.c)',
+  'FLEX_TARGET(MyScanner scanner.l output/scanner.cpp)',
+  'ADD_FLEX_BISON_DEPENDENCY(MyScanner MyParser)',
+].join('\n');
+
+test('uppercase ADD_FLEX_BISON_DEPENDENCY', () => {
+  const result = parseCmakePairs(cmakeUppercase);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].bisonFile, 'parser.y');
+  assert.strictEqual(result[0].flexFile, 'scanner.l');
+});
+
+const cmakeLowercase = [
+  'bison_target(MyParser parser.y output/parser.tab.c)',
+  'flex_target(MyScanner scanner.l output/scanner.cpp)',
+  'add_flex_bison_dependency(MyScanner MyParser)',
+].join('\n');
+
+test('lowercase add_flex_bison_dependency', () => {
+  const result = parseCmakePairs(cmakeLowercase);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].bisonFile, 'parser.y');
+  assert.strictEqual(result[0].flexFile, 'scanner.l');
+});
+
+const cmakeMixedCase = [
+  'Bison_Target(MyParser parser.y output/parser.tab.c)',
+  'Flex_Target(MyScanner scanner.l output/scanner.cpp)',
+  'Add_Flex_Bison_Dependency(MyScanner MyParser)',
+].join('\n');
+
+test('mixed case Add_Flex_Bison_Dependency', () => {
+  const result = parseCmakePairs(cmakeMixedCase);
+  assert.strictEqual(result.length, 1);
+});
+
+test('no ADD_FLEX_BISON_DEPENDENCY → no pairs', () => {
+  const result = parseCmakePairs('BISON_TARGET(P p.y out.c)\nFLEX_TARGET(F f.l out.cpp)');
+  assert.strictEqual(result.length, 0);
+});
+
+test('mismatched target names → no pairs', () => {
+  const result = parseCmakePairs([
+    'BISON_TARGET(ParserA a.y out.c)',
+    'FLEX_TARGET(ScannerB b.l out.cpp)',
+    'ADD_FLEX_BISON_DEPENDENCY(ScannerX ParserY)',
+  ].join('\n'));
+  assert.strictEqual(result.length, 0);
+});
+
+// ─── generatedCandidates: Bison ───────────────────────────────────────────────
+
+console.log('\ngeneratedCandidates — Bison');
+
+test('bison: GNU .tab.c and .tab.h present', () => {
+  const result = generatedCandidates('/src/calc.y', undefined, 'bison');
+  const files = result.map(r => path.basename(r.file));
+  assert.ok(files.includes('calc.tab.c'), 'missing calc.tab.c');
+  assert.ok(files.includes('calc.tab.cpp'), 'missing calc.tab.cpp');
+  assert.ok(files.includes('calc.tab.h'), 'missing calc.tab.h');
+  assert.ok(files.includes('calc.output'), 'missing calc.output');
+  assert.ok(files.includes('calc.xml'), 'missing calc.xml');
+  assert.ok(files.includes('calc.gv'), 'missing calc.gv');
+});
+
+test('bison: automake _tab.c and _tab.h present', () => {
+  const result = generatedCandidates('/src/calc.y', undefined, 'bison');
+  const files = result.map(r => path.basename(r.file));
+  assert.ok(files.includes('calc_tab.c'), 'missing calc_tab.c');
+  assert.ok(files.includes('calc_tab.cpp'), 'missing calc_tab.cpp');
+  assert.ok(files.includes('calc_tab.h'), 'missing calc_tab.h');
+  assert.ok(files.includes('calc_tab.hpp'), 'missing calc_tab.hpp');
+});
+
+test('bison: buildDir overrides source directory', () => {
+  const result = generatedCandidates('/src/calc.y', '/build', 'bison');
+  assert.ok(result.every(r => r.file.startsWith('/build')), 'all files should be in /build');
+});
+
+// ─── generatedCandidates: Flex ───────────────────────────────────────────────
+
+console.log('\ngeneratedCandidates — Flex');
+
+test('flex: GNU lex.yy.c and lex.yy.cpp present', () => {
+  const result = generatedCandidates('/src/calc.l', undefined, 'flex');
+  const files = result.map(r => path.basename(r.file));
+  assert.ok(files.includes('lex.yy.c'), 'missing lex.yy.c');
+  assert.ok(files.includes('lex.yy.cpp'), 'missing lex.yy.cpp');
+});
+
+test('flex: automake lex.stem.c and lex.stem.cpp present', () => {
+  const result = generatedCandidates('/src/calc.l', undefined, 'flex');
+  const files = result.map(r => path.basename(r.file));
+  assert.ok(files.includes('lex.calc.c'), 'missing lex.calc.c');
+  assert.ok(files.includes('lex.calc.cpp'), 'missing lex.calc.cpp');
+});
+
+// ─── Empty WorkspaceIndex ─────────────────────────────────────────────────────
+
+console.log('\nWorkspaceIndex — empty');
+
+test('empty WorkspaceIndex: all queries return empty without throwing', () => {
+  const idx = new WorkspaceIndex('');
+  assert.deepStrictEqual(idx.getBisonFiles(), []);
+  assert.deepStrictEqual(idx.getFlexFiles(), []);
+  assert.deepStrictEqual(idx.getAllPairs(), []);
+  assert.deepStrictEqual(idx.getBuildInfo(), []);
+  assert.strictEqual(idx.getPairForBison('file:///x.y'), undefined);
+  assert.strictEqual(idx.getPairForFlex('file:///x.l'), undefined);
+  assert.deepStrictEqual(idx.getGeneratedFilesFor('file:///x.y'), []);
+});
+
+test('empty WorkspaceIndex: initialize with empty folders is a no-op', async () => {
+  const idx = new WorkspaceIndex('');
+  await idx.initialize([]);
+  assert.deepStrictEqual(idx.getBisonFiles(), []);
+});
+
+// ─── Results ──────────────────────────────────────────────────────────────────
+
+setImmediate(() => {
+  console.log('\n==================================================');
+  console.log(`  RESULTS: ${passed} passed, ${failed} failed`);
+  console.log('==================================================\n');
+  if (failed > 0) process.exit(1);
+});

--- a/tests/test-project-model.ts
+++ b/tests/test-project-model.ts
@@ -211,6 +211,8 @@ test('flex: GNU lex.yy.c and lex.yy.cpp present', () => {
   const files = result.map(r => path.basename(r.file));
   assert.ok(files.includes('lex.yy.c'), 'missing lex.yy.c');
   assert.ok(files.includes('lex.yy.cpp'), 'missing lex.yy.cpp');
+  assert.ok(files.includes('lex_yy.c'), 'missing lex_yy.c');
+  assert.ok(files.includes('lex_yy.cpp'), 'missing lex_yy.cpp');
 });
 
 test('flex: automake lex.stem.c and lex.stem.cpp present', () => {


### PR DESCRIPTION
## Type of change
- [x] New feature
- [x] Refactor / internal improvement

## What does this PR do?

Adds the V2 ProjectModel foundation layer (PR 4 of the V2 workbench roadmap).

Three new files under `server/src/project/`:

- **`projectTypes.ts`** — canonical TypeScript interfaces: `BisonFlexProjectModel`, `BisonSourceFile`, `FlexSourceFile`, `ParserScannerPair`, `GeneratedFile`, `BuildSystemInfo`
- **`projectScanner.ts`** — 4-step workspace discovery algorithm: recursive file walk (`.y`/`.yy`/`.l`/`.ll`), build system detection (CMake/Make/automake), pair detection (explicit via `add_flex_bison_dependency` + inferred via name-stem heuristic), generated file detection
- **`projectModel.ts`** — `WorkspaceIndex` singleton: non-blocking `initialize()` via `setImmediate`, incremental `onFileChange()`, 8 query methods (`getPairForBison`, `getPairForFlex`, `getBisonFiles`, `getFlexFiles`, `getAllPairs`, `getGeneratedFilesFor`, `getBuildInfo`, `getModel`)

`server.ts` gains a `workspaceIndex` variable and an `onInitialized` handler that bootstraps the index from workspace folders.

## Related issue

Part of the V2 workbench roadmap — no standalone issue.

## How to test manually

1. Open a workspace containing a `.y` and `.l` file with matching stems (e.g. `calc.y` / `calc.l`)
2. Extension loads → `WorkspaceIndex.initialize()` runs in background
3. `getAllPairs()` returns one pair with `confidence: 'inferred'`
4. For a workspace with `CMakeLists.txt` using `add_flex_bison_dependency(...)`, pair has `confidence: 'explicit'`

## Checklist
- [x] `npm run compile` passes with no new errors
- [x] Existing tests pass: `test-parsers.ts` 356/356, `test-diagnostic-codes.ts` 211/211
- [x] No provider files modified
- [x] `WorkspaceIndex` degrades gracefully when no workspace folders are open